### PR TITLE
go1.16 deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang
 
 LABEL name="Golang Pipeline"
-LABEL maintainer="jesseobrien"
+LABEL maintainer="flypay"
 LABEL version="0.2.9"
-LABEL repository="https://github.com/jesseobrien/golang-pipeline"
+LABEL repository="https://github.com/flypay/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"
 LABEL com.github.actions.description="Introduction"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-
+.PHONY: ver sync
 ver:
 	@read -p "Enter a new version:" version; \
 	old_version=$(shell grep -o "\d.\d.\d" Dockerfile);  \
@@ -9,4 +9,3 @@ sync:
 	cat setup.sh | tee $(shell find . -name "gp-setup.sh")
 	cat linter.sh | tee $(shell find . -name "gp-linter.sh")
 	cat release.sh | tee $(shell find . -name "gp-release.sh")
-.PHONY: ver sync

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jesseobrien/golang-pipeline/go1.14/release@master
 # Run release in Go1.15
 jesseobrien/golang-pipeline/go1.15/release@master
 # Run release in Go1.16
-jesseobrien/golang-pipeline/go1.15/release@master
+jesseobrien/golang-pipeline/go1.16/release@master
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ curl -o- https://raw.githubusercontent.com/jesseobrien/golang-pipeline/master/in
 
 # Workflows
 
-golang-pipeline supports Go version 1.11, 1.12, 1.13, 1.14 and 1.15 and each version has its tests, linters and release.
+golang-pipeline supports Go version 1.11, 1.12, 1.13, 1.14, 1.15 and 1.16 and each version has its tests, linters and release.
 
 **Format**
 
@@ -34,6 +34,8 @@ jesseobrien/golang-pipeline/go1.13/release@master
 # Run release in Go1.14
 jesseobrien/golang-pipeline/go1.14/release@master
 # Run release in Go1.15
+jesseobrien/golang-pipeline/go1.15/release@master
+# Run release in Go1.16
 jesseobrien/golang-pipeline/go1.15/release@master
 
 ```

--- a/go1.16/linter/Dockerfile
+++ b/go1.16/linter/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.16-alpine
+
+LABEL name="Golang Pipeline"
+LABEL maintainer="flypay"
+LABEL version="0.2.9"
+LABEL repository="https://github.com/flypay/golang-pipeline"
+
+LABEL com.github.actions.name="Golang Pipeline"
+LABEL com.github.actions.description="Run Golang commands"
+LABEL com.github.actions.icon="box"
+LABEL com.github.actions.color="blue"
+
+COPY entrypoint.sh /entrypoint.sh
+COPY gp-linter.sh /gp-linter.sh
+COPY gp-setup.sh /gp-setup.sh
+
+RUN apk add --no-cache curl jq git build-base
+ENTRYPOINT ["/entrypoint.sh"]

--- a/go1.16/linter/entrypoint.sh
+++ b/go1.16/linter/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -exuo pipefail
+
+. /gp-setup.sh
+. /gp-linter.sh

--- a/go1.16/linter/gp-linter.sh
+++ b/go1.16/linter/gp-linter.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -exuo pipefail
+
+STATICCHECK=${INPUT_STATICCHECK:-on}
+ERRCHECK=${INPUT_ERRCHECK:-on}
+GOLINT=${INPUT_GOLINT:-off}
+GOLINTPATH=${INPUT_GOLINTPATH:-.}
+MISSPELL=${INPUT_MISSPELL:-off}
+
+if [[ $STATICCHECK == "on" ]]; then
+  # https://www.staticcheck.io/docs/checks
+  go get honnef.co/go/tools/cmd/staticcheck 
+  staticcheck ./...
+fi
+
+if [[ $GOLINT == "on" ]]; then
+  # https://github.com/golang/lint
+  go get -u golang.org/x/lint/golint
+  golint -set_exit_status=1 ${GOLINTPATH}/...
+fi
+
+if [[ $ERRCHECK == "on" ]]; then
+  # https://github.com/kisielk/errcheck
+  go get -u github.com/kisielk/errcheck
+  errcheck ./...
+fi
+
+if [[ $MISSPELL == "on" ]]; then
+  # https://github.com/client9/misspell
+  go get -u github.com/client9/misspell/cmd/misspell
+  misspell -error  $(find . -name "*.go")
+fi

--- a/go1.16/linter/gp-setup.sh
+++ b/go1.16/linter/gp-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -exuo pipefail
+
+export GO111MODULE=on
+
+WORK_SPACE=${PROJECT_PATH:-}
+
+# Set PROJECT_PATH to change your working directory
+if [ -z "${WORK_SPACE}" ]; then
+  WORK_SPACE="."
+fi
+
+cd $WORK_SPACE

--- a/go1.16/release/Dockerfile
+++ b/go1.16/release/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.16-alpine
+
+LABEL name="Golang Pipeline"
+LABEL maintainer="flypay"
+LABEL version="0.2.9"
+LABEL repository="https://github.com/flypay/golang-pipeline"
+
+LABEL com.github.actions.name="Golang Pipeline"
+LABEL com.github.actions.description="Run Golang commands"
+LABEL com.github.actions.icon="box"
+LABEL com.github.actions.color="blue"
+
+COPY entrypoint.sh /entrypoint.sh
+COPY gp-release.sh /gp-release.sh
+COPY gp-setup.sh /gp-setup.sh
+
+RUN apk add --no-cache curl jq git build-base
+ENTRYPOINT ["/entrypoint.sh"]

--- a/go1.16/release/entrypoint.sh
+++ b/go1.16/release/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -exuo pipefail
+
+. /gp-setup.sh
+. /gp-release.sh

--- a/go1.16/release/gp-release.sh
+++ b/go1.16/release/gp-release.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -exuo pipefail
+
+EVENT_DATA=$(cat $GITHUB_EVENT_PATH)
+UPLOAD_URL=$(echo $EVENT_DATA | jq -r .release.upload_url)
+UPLOAD_URL=${UPLOAD_URL/\{?name,label\}/}
+
+if [ -z "${BINARY_NAME}" ]; then
+  BINARY_NAME=$(basename $GITHUB_REPOSITORY)
+fi
+
+EXT=""
+if [ $GOOS == 'windows' ]; then
+    EXT='.exe'
+fi
+
+ARTIFACT_NAME="${BINARY_NAME}-${GOOS}-${GOARCH}${EXT}"
+
+echo "Building $ARTIFACT_NAME" 
+CGO_ENABLED=0 go build -ldflags "-s -w" -o "${BINARY_NAME}"
+
+tar cvfz tmp.tgz "${BINARY_NAME}"
+CHECKSUM=$(sha256sum tmp.tgz | cut -d ' ' -f 1)
+
+curl \
+  --fail \
+  -X POST \
+  --data-binary @tmp.tgz\
+  -H 'Content-Type: application/octet-stream' \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${UPLOAD_URL}?name=${ARTIFACT_NAME}.tar.gz"
+
+
+curl \
+  -X POST \
+  --data "$CHECKSUM" \
+  -H 'Content-Type: text/plain' \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${UPLOAD_URL}?name=${ARTIFACT_NAME}_checksum_sha256.txt"

--- a/go1.16/release/gp-setup.sh
+++ b/go1.16/release/gp-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -exuo pipefail
+
+export GO111MODULE=on
+
+WORK_SPACE=${PROJECT_PATH:-}
+
+# Set PROJECT_PATH to change your working directory
+if [ -z "${WORK_SPACE}" ]; then
+  WORK_SPACE="."
+fi
+
+cd $WORK_SPACE

--- a/go1.16/test/Dockerfile
+++ b/go1.16/test/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.15-alpine
+
+LABEL name="Golang Pipeline"
+LABEL maintainer="jesseobrien"
+LABEL version="0.2.9"
+LABEL repository="https://github.com/jesseobrien/golang-pipeline"
+
+LABEL com.github.actions.name="Golang Pipeline"
+LABEL com.github.actions.description="Run Golang commands"
+LABEL com.github.actions.icon="box"
+LABEL com.github.actions.color="blue"
+
+COPY entrypoint.sh /entrypoint.sh
+COPY gp-setup.sh /gp-setup.sh
+
+RUN apk add --no-cache curl jq git build-base
+ENTRYPOINT ["/entrypoint.sh"]

--- a/go1.16/test/Dockerfile
+++ b/go1.16/test/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.16-alpine
+FROM golang:1.15-alpine
 
 LABEL name="Golang Pipeline"
-LABEL maintainer="jesseobrien"
+LABEL maintainer="flypay"
 LABEL version="0.2.9"
-LABEL repository="https://github.com/jesseobrien/golang-pipeline"
+LABEL repository="https://github.com/flypay/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"
 LABEL com.github.actions.description="Run Golang commands"

--- a/go1.16/test/Dockerfile
+++ b/go1.16/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="jesseobrien"

--- a/go1.16/test/entrypoint.sh
+++ b/go1.16/test/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -exuo pipefail
+
+. /gp-setup.sh
+go test ./...

--- a/go1.16/test/gp-setup.sh
+++ b/go1.16/test/gp-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -exuo pipefail
+
+export GO111MODULE=on
+
+WORK_SPACE=${PROJECT_PATH:-}
+
+# Set PROJECT_PATH to change your working directory
+if [ -z "${WORK_SPACE}" ]; then
+  WORK_SPACE="."
+fi
+
+cd $WORK_SPACE


### PR DESCRIPTION
**WHY**
We need to have go v.16 in the go-kit pipeline for github actions